### PR TITLE
Wifi Support & Checks

### DIFF
--- a/ios-deploy.c
+++ b/ios-deploy.c
@@ -1162,8 +1162,7 @@ void upload_file(AMDeviceRef device) {
     free(file_content);
 }
 
-void handle_device(AMDeviceRef device) {    printf("DEVICE CONNECTION: %d\n", AMDeviceGetInterfaceType(device));
-
+void handle_device(AMDeviceRef device) {
     if (found_device) 
         return; // handle one device only
 


### PR DESCRIPTION
This pull request is built on top of https://github.com/phonegap/ios-deploy/pull/47 that tries to diagnose bug #11.

This replaces most app installations calls by the AMDeviceSecure\* versions of the API which correctly supports Wifi deployment. I'm unable, and think it's not possible, to start a debug session over Wifi, but with this pull request we're now able to deploy apps wirelessly.

I've implemented checks to detect attempts of debugging over Wifi and instead of a puzzling "assert" log, it will explain the problem. Devices are also better identified to help diagnose and find the culprit.

Additionally, if attempting to start a debug (or list connected devices with the debug flag active) it will now wait for a USB connected device. On timeout it will fallback to the previous/default behaviour of returning the first device found. If the debug flag is off or a specific device ID is set the behaviour stays unchanged (first device is used).
