### PR TITLE
fix lldb status checking

### DIFF
--- a/ios-deploy.c
+++ b/ios-deploy.c
@@ -77,7 +77,7 @@ def connect_command(debugger, command, result, internal_dict):\n\
     listener = lldb.target.GetDebugger().GetListener()\n\
     listener.StartListeningForEvents(process.GetBroadcaster(), lldb.SBProcess.eBroadcastBitStateChanged)\n\
     events = []\n\
-    state = lldb.eStateInvalid\n\
+    state = (process.GetState() or lldb.eStateInvalid)\n\
     while state != lldb.eStateConnected:\n\
         event = lldb.SBEvent()\n\
         if listener.WaitForEvent(1, event):\n\


### PR DESCRIPTION
Possible fix for issue #61 

Something changed on lldb or internal Apple apis and lldb is already connected at the time of the check. This fixes the issue and should be backwards compatible.
