### PR TITLE
Fixed problem with the parser of the value of the parameter -i.

### DIFF
--- a/ios-deploy.c
+++ b/ios-deploy.c
@@ -1510,7 +1510,7 @@ int main(int argc, char *argv[]) {
     };
     char ch;
 
-    while ((ch = getopt_long(argc, argv, "VmcdvunrILib:a:t:g:x:p:1:2:o:l::w::", longopts, NULL)) != -1)
+    while ((ch = getopt_long(argc, argv, "VmcdvunrILi:b:a:t:g:x:p:1:2:o:l::w::", longopts, NULL)) != -1)
     {
         switch (ch) {
         case 'm':


### PR DESCRIPTION
ERROR: ios-deploy could not be used with more than one device connected.
CAUSE: The value of the parameter -i was always NULL so the default device was always the last connected. 
SOLUTION: In the parameters parser string, added the char ':' after the -i parameter.
