### PR TITLE
Add installation instructions in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Install and debug iOS apps without using Xcode. Designed to work on un-jailbroke
 * You need to have a valid iOS development certificate installed.
 * Xcode 6.1 should be installed
 
+## Installation
+
+```bash
+$ npm install -g ios-deploy
+```
+
 ## Usage
 
     Usage: ios-deploy [OPTION]...


### PR DESCRIPTION
I scrolled down in the README and did not found installation instructions, realised that it was via npm after running `$ phonegap run ios` and getting more details. 
