### PR TITLE
Add command to just stop the app

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -50,6 +50,12 @@ const char* lldb_prep_noninteractive_justlaunch_cmds = "\
     safequit\n\
 ";
 
+const char* lldb_prep_stopapp_cmds = "\
+    run\n\
+    kill\n\
+    autoexit\n\
+";
+
 const char* lldb_prep_noninteractive_cmds = "\
     run\n\
     autoexit\n\
@@ -81,6 +87,7 @@ char const*upload_pathname = NULL;
 char *bundle_id = NULL;
 bool interactive = true;
 bool justlaunch = false;
+bool stopapp = false;
 char *app_path = NULL;
 char *device_id = NULL;
 char *args = NULL;
@@ -747,7 +754,9 @@ void write_lldb_prep_cmds(AMDeviceRef device, CFURLRef disk_app_url) {
     const char* extra_cmds;
     if (!interactive)
     {
-        if (justlaunch)
+        if (stopapp)
+          extra_cmds = lldb_prep_stopapp_cmds;
+        else if (justlaunch)
           extra_cmds = lldb_prep_noninteractive_justlaunch_cmds;
         else
           extra_cmds = lldb_prep_noninteractive_cmds;
@@ -1741,6 +1750,7 @@ void usage(const char* app) {
         @"  -u, --unbuffered             don't buffer stdout\n"
         @"  -n, --nostart                do not start the app when debugging\n"
         @"  -I, --noninteractive         start in non interactive mode (quit when app crashes or exits)\n"
+        @"  -S, --stopapp                stop the app\n"
         @"  -L, --justlaunch             just launch the app and exit lldb\n"
         @"  -v, --verbose                enable verbose output\n"
         @"  -m, --noinstall              directly start debugging without app install (-d not required)\n"
@@ -1785,6 +1795,7 @@ int main(int argc, char *argv[]) {
         { "unbuffered", no_argument, NULL, 'u' },
         { "nostart", no_argument, NULL, 'n' },
         { "noninteractive", no_argument, NULL, 'I' },
+        { "stopapp", no_argument, NULL, 'S' },
         { "justlaunch", no_argument, NULL, 'L' },
         { "detect", no_argument, NULL, 'c' },
         { "version", no_argument, NULL, 'V' },
@@ -1806,7 +1817,7 @@ int main(int argc, char *argv[]) {
     };
     char ch;
 
-    while ((ch = getopt_long(argc, argv, "VmcdvunrILeD:R:i:b:a:t:g:x:p:1:2:o:l::w::9::B::W", longopts, NULL)) != -1)
+    while ((ch = getopt_long(argc, argv, "VSmcdvunrILeD:R:i:b:a:t:g:x:p:1:2:o:l::w::9::B::W", longopts, NULL)) != -1)
     {
         switch (ch) {
         case 'm':
@@ -1841,6 +1852,11 @@ int main(int argc, char *argv[]) {
             interactive = false;
             debug = 1;
             break;
+        case 'S':
+            stopapp = true;
+            justlaunch = true;
+            install = false;
+            debug = 1;
         case 'L':
             interactive = false;
             justlaunch = true;


### PR DESCRIPTION
Implements #117

Tested on OSX Yosemite 10.10.5, iOS 9.2.1, and iOS 8.2

Usage: `ios-deploy --stopapp --bundle path/to/app`

Trying to stop the app when the app is not running will launch the app, and then immediately shut it back down.
