### PR TITLE
added support for AppleTV OS

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -185,23 +185,14 @@ Boolean path_exists(CFTypeRef path) {
 
 CFStringRef find_path(CFStringRef rootPath, CFStringRef namePattern, CFStringRef expression) {
     FILE *fpipe = NULL;
-    CFStringRef quotedRootPath = rootPath;
     CFStringRef cf_command;
     CFRange slashLocation;
 
-    if (CFStringGetCharacterAtIndex(rootPath, 0) != '`') {
-        quotedRootPath = CFStringCreateWithFormat(NULL, NULL, CFSTR("'%@'"), rootPath);
-    }
-
     slashLocation = CFStringFind(namePattern, CFSTR("/"), 0);
     if (slashLocation.location == kCFNotFound) {
-        cf_command = CFStringCreateWithFormat(NULL, NULL, CFSTR("find %@ -name '%@' %@ 2>/dev/null | sort | tail -n 1"), quotedRootPath, namePattern, expression);
+        cf_command = CFStringCreateWithFormat(NULL, NULL, CFSTR("find %@ -name '%@' %@ 2>/dev/null | sort | tail -n 1"), rootPath, namePattern, expression);
     } else {
-        cf_command = CFStringCreateWithFormat(NULL, NULL, CFSTR("find %@ -path '%@' %@ 2>/dev/null | sort | tail -n 1"), quotedRootPath, namePattern, expression);
-    }
-
-    if (quotedRootPath != rootPath) {
-        CFRelease(quotedRootPath);
+        cf_command = CFStringCreateWithFormat(NULL, NULL, CFSTR("find %@ -path '%@' %@ 2>/dev/null | sort | tail -n 1"), rootPath, namePattern, expression);
     }
 
     char command[1024] = { '\0' };
@@ -445,25 +436,39 @@ CFMutableArrayRef get_device_product_version_parts(AMDeviceRef device) {
 CFStringRef copy_device_support_path(AMDeviceRef device) {
     CFStringRef version = NULL;
     CFStringRef build = AMDeviceCopyValue(device, 0, CFSTR("BuildVersion"));
+    CFStringRef deviceClass = AMDeviceCopyValue(device, 0, CFSTR("DeviceClass"));
     CFStringRef path = NULL;
     CFMutableArrayRef version_parts = get_device_product_version_parts(device);
 
+    NSLogVerbose(@"Device Class: %@", deviceClass);
+    NSLogVerbose(@"build: %@", build);
+
+    CFStringRef deviceClassPath_platform;
+    CFStringRef deviceClassPath_alt;
+    if (CFStringCompare(CFSTR("AppleTV"), deviceClass, 0) == kCFCompareEqualTo) {
+      deviceClassPath_platform = CFSTR("Platforms/AppleTVOS.platform/DeviceSupport");
+      deviceClassPath_alt = CFSTR("tvOS\\ DeviceSupport");
+    } else {
+      deviceClassPath_platform = CFSTR("Platforms/iPhoneOS.platform/DeviceSupport");
+      deviceClassPath_alt = CFSTR("iOS\\ DeviceSupport");
+    }
     while (CFArrayGetCount(version_parts) > 0) {
         version = CFStringCreateByCombiningStrings(NULL, version_parts, CFSTR("."));
+        NSLogVerbose(@"version: %@", version);
         if (path == NULL) {
-            path = copy_xcode_path_for(CFSTR("iOS DeviceSupport"), CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (%@)"), version, build));
+            path = copy_xcode_path_for(deviceClassPath_alt, CFStringCreateWithFormat(NULL, NULL, CFSTR("%@\\ \\(%@\\)"), version, build));
         }
         if (path == NULL) {
-            path = copy_xcode_path_for(CFSTR("Platforms/iPhoneOS.platform/DeviceSupport"), CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (%@)"), version, build));
+            path = copy_xcode_path_for(deviceClassPath_platform, CFStringCreateWithFormat(NULL, NULL, CFSTR("%@\\ \\(%@\\)"), version, build));
         }
         if (path == NULL) {
-            path = copy_xcode_path_for(CFSTR("Platforms/iPhoneOS.platform/DeviceSupport"), CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (*)"), version));
+            path = copy_xcode_path_for(deviceClassPath_platform, CFStringCreateWithFormat(NULL, NULL, CFSTR("%@\\ \\(*\\)"), version));
         }
         if (path == NULL) {
-            path = copy_xcode_path_for(CFSTR("Platforms/iPhoneOS.platform/DeviceSupport"), version);
+            path = copy_xcode_path_for(deviceClassPath_platform, version);
         }
         if (path == NULL) {
-            path = copy_xcode_path_for(CFSTR("Platforms/iPhoneOS.platform/DeviceSupport/Latest"), CFSTR(""));
+            path = copy_xcode_path_for(CFStringCreateWithFormat(NULL, NULL, CFSTR("%@%@"), deviceClassPath_platform, CFSTR("/Latest")), CFSTR(""));
         }
         CFRelease(version);
         if (path != NULL) {
@@ -474,7 +479,7 @@ CFStringRef copy_device_support_path(AMDeviceRef device) {
 
     CFRelease(version_parts);
     CFRelease(build);
-
+    CFRelease(deviceClass);
     if (path == NULL)
         on_error(@"Unable to locate DeviceSupport directory. This probably means you don't have Xcode installed, you will need to launch the app manually and logging output will not be shown!");
 
@@ -484,25 +489,40 @@ CFStringRef copy_device_support_path(AMDeviceRef device) {
 CFStringRef copy_developer_disk_image_path(AMDeviceRef device) {
     CFStringRef version = NULL;
     CFStringRef build = AMDeviceCopyValue(device, 0, CFSTR("BuildVersion"));
+    CFStringRef deviceClass = AMDeviceCopyValue(device, 0, CFSTR("DeviceClass"));
     CFStringRef path = NULL;
     CFMutableArrayRef version_parts = get_device_product_version_parts(device);
 
+    NSLogVerbose(@"Device Class: %@", deviceClass);
+    NSLogVerbose(@"build: %@", build);
+    CFStringRef deviceClassPath_platform;
+    CFStringRef deviceClassPath_alt;
+    if (CFStringCompare(CFSTR("AppleTV"), deviceClass, 0) == kCFCompareEqualTo) {
+      deviceClassPath_platform = CFSTR("Platforms/AppleTVOS.platform/DeviceSupport");
+      deviceClassPath_alt = CFSTR("tvOS\\ DeviceSupport");
+    } else {
+      deviceClassPath_platform = CFSTR("Platforms/iPhoneOS.platform/DeviceSupport");
+      deviceClassPath_alt = CFSTR("iOS\\ DeviceSupport");
+    }
+    // path = getPathForTVOS(device);
     while (CFArrayGetCount(version_parts) > 0) {
         version = CFStringCreateByCombiningStrings(NULL, version_parts, CFSTR("."));
-    if (path == NULL) {
-            path = copy_xcode_path_for(CFSTR("iOS DeviceSupport"), CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (%@)/DeveloperDiskImage.dmg"), version, build));
+        NSLogVerbose(@"version: %@", version);
+
+        if (path == NULL) {
+            path = copy_xcode_path_for(CFStringCreateWithFormat(NULL, NULL, CFSTR("%@/%@\\ \\(%@\\)"), deviceClassPath_alt, version, build), CFSTR("DeveloperDiskImage.dmg"));
         }
         if (path == NULL) {
-            path = copy_xcode_path_for(CFSTR("Platforms/iPhoneOS.platform/DeviceSupport"), CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (%@)/DeveloperDiskImage.dmg"), version, build));
-    }
-        if (path == NULL) {
-             path = copy_xcode_path_for(CFSTR("Platforms/iPhoneOS.platform/DeviceSupport"), CFStringCreateWithFormat(NULL, NULL, CFSTR("*/%@ (*)/DeveloperDiskImage.dmg"), version));
+            path = copy_xcode_path_for(deviceClassPath_platform, CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (%@)/DeveloperDiskImage.dmg"), version, build));
         }
         if (path == NULL) {
-            path = copy_xcode_path_for(CFSTR("Platforms/iPhoneOS.platform/DeviceSupport"), CFStringCreateWithFormat(NULL, NULL, CFSTR("%@/DeveloperDiskImage.dmg"), version));
+            path = copy_xcode_path_for(CFStringCreateWithFormat(NULL, NULL, CFSTR("%@/%@\\ \\(*\\)"), deviceClassPath_platform, version), CFSTR("DeveloperDiskImage.dmg"));
         }
         if (path == NULL) {
-            path = copy_xcode_path_for(CFSTR("Platforms/iPhoneOS.platform/DeviceSupport/Latest"), CFSTR("DeveloperDiskImage.dmg"));
+            path = copy_xcode_path_for(deviceClassPath_platform, CFStringCreateWithFormat(NULL, NULL, CFSTR("%@/DeveloperDiskImage.dmg"), version));
+        }
+        if (path == NULL) {
+            path = copy_xcode_path_for(CFStringCreateWithFormat(NULL, NULL, CFSTR("%@/Latest"), deviceClassPath_platform), CFSTR("/DeveloperDiskImage.dmg"));
         }
         CFRelease(version);
         if (path != NULL) {
@@ -513,6 +533,7 @@ CFStringRef copy_developer_disk_image_path(AMDeviceRef device) {
 
     CFRelease(version_parts);
     CFRelease(build);
+    CFRelease(deviceClass);
     if (path == NULL)
         on_error(@"Unable to locate DeveloperDiskImage.dmg. This probably means you don't have Xcode installed, you will need to launch the app manually and logging output will not be shown!");
 
@@ -643,7 +664,7 @@ CFStringRef copy_disk_app_identifier(CFURLRef disk_app_url) {
     CFURLRef plist_url = CFURLCreateCopyAppendingPathComponent(NULL, disk_app_url, CFSTR("Info.plist"), false);
     CFReadStreamRef plist_stream = CFReadStreamCreateWithFile(NULL, plist_url);
     if (!CFReadStreamOpen(plist_stream)) {
-      on_error(@"Cannot read Info.plist file: %@", plist_url);
+        on_error(@"Cannot read Info.plist file: %@", plist_url);
     }
 
     CFPropertyListRef plist = CFPropertyListCreateWithStream(NULL, plist_stream, 0, kCFPropertyListImmutable, NULL, NULL);
@@ -1676,7 +1697,7 @@ void device_callback(struct am_device_notification_callback_info *info, void *ar
     switch (info->msg) {
         case ADNCI_MSG_CONNECTED:
             if(device_id != NULL || !debug || AMDeviceGetInterfaceType(info->dev) != 2) {
-        if (no_wifi && AMDeviceGetInterfaceType(info->dev) == 2)
+                if (no_wifi && AMDeviceGetInterfaceType(info->dev) == 2)
                 {
                     NSLogVerbose(@"Skipping wifi device (type: %d)", AMDeviceGetInterfaceType(info->dev));
                 }


### PR DESCRIPTION
Hello,

We use your work internally in my company, and we needed to deploy automatically on tvOS, so I tweaked the code to allow that. (thanks by the way for continuing ios-deploy :tada: )

Please consider my changes.

Some explaination about the patch : 

- **find_path()** was not working for some paths (I believe it was "iOS DeviceSupport", probably because of the space), so I tweaked it a little bit because my tvOS support path was in this folder.
My fix to this issue has not been to fix **find_path()** per se, but to make it lower level, and escape the paths before calling find_path.

- I added a deviceClassPath variable (2 to be exact, but you can read :+1: ), to adapt with tvOS location, this change is easy to read I believe.


I submit this change from home, so I can't test it with an AppleTV, and your codebase changed slightly, so maybe the patch isn't ready, but it shouldn't be far from it, as it worked on my workplace.

I would appreciate feedbacks, thanks :smile: 