### PR TITLE
Fixed a problem with inability to pass arguments through command line parameters

### DIFF
--- a/src/scripts/lldb.py
+++ b/src/scripts/lldb.py
@@ -35,8 +35,8 @@ def run_command(debugger, command, result, internal_dict):
     args_arr = []
     if len(args) > 1:
         args_arr = shlex.split(args[1])
-    else:
-        args_arr = shlex.split('{args}')
+    args_arr = args_arr + shlex.split('{args}')
+
     lldb.target.Launch(lldb.SBLaunchInfo(args_arr), error)
     lockedstr = ': Locked'
     if lockedstr in str(error):


### PR DESCRIPTION
Fixes #256
In my case the `command = '-X true --'` which makes `args = ['-X true ', '']` and it compleately ignored what we have in `'{args}'`
