### PR TITLE
Moved device database to a separate header.

### DIFF
--- a/ios-deploy.xcodeproj/project.pbxproj
+++ b/ios-deploy.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		7B28C98C1DC10655009569B6 /* device_db.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = device_db.h; sourceTree = "<group>"; };
 		7E1C00CC1C3C93AF00D686B5 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
 		7E1C00CF1C3C9ABB00D686B5 /* lldb.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; name = lldb.py; path = src/scripts/lldb.py; sourceTree = SOURCE_ROOT; };
 		7E1C00D11C3C9CB000D686B5 /* lldb.py.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lldb.py.h; sourceTree = "<group>"; };
@@ -122,6 +123,7 @@
 				7E7089991B587DE4004D23AA /* ios-deploy.m */,
 				7E70899A1B587DE4004D23AA /* errors.h */,
 				7E70899B1B587DE4004D23AA /* MobileDevice.h */,
+				7B28C98C1DC10655009569B6 /* device_db.h */,
 			);
 			name = "ios-deploy";
 			path = "src/ios-deploy";

--- a/src/ios-deploy/device_db.h
+++ b/src/ios-deploy/device_db.h
@@ -1,0 +1,110 @@
+//
+//  devices.h
+//  ios-deploy
+//
+//  Created by Gusts Kaksis on 26/10/2016.
+//  Copyright © 2016 PhoneGap. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#define ADD_DEVICE(model, name, sdk, arch) {CFSTR(model), CFSTR(name), CFSTR(sdk), CFSTR(arch)}
+
+typedef struct {
+    CFStringRef model;
+    CFStringRef name;
+    CFStringRef sdk;
+    CFStringRef arch;
+} device_desc;
+
+#define UNKNOWN_DEVICE_IDX 0
+
+device_desc device_db[] = {
+                          ADD_DEVICE("UNKN",   "Unknown Device",             "uknownos", "unkarch"),
+
+                          // iPod Touch
+
+                          ADD_DEVICE("N45AP",  "iPod Touch",                 "iphoneos", "armv7"),
+                          ADD_DEVICE("N72AP",  "iPod Touch 2G",              "iphoneos", "armv7"),
+                          ADD_DEVICE("N18AP",  "iPod Touch 3G",              "iphoneos", "armv7"),
+                          ADD_DEVICE("N81AP",  "iPod Touch 4G",              "iphoneos", "armv7"),
+                          ADD_DEVICE("N78AP",  "iPod Touch 5G",              "iphoneos", "armv7"),
+                          ADD_DEVICE("N78AAP", "iPod Touch 5G",              "iphoneos", "armv7"),
+                          ADD_DEVICE("N102AP", "iPod Touch 6G",              "iphoneos", "arm64"),
+
+                          // iPad
+
+                          ADD_DEVICE("K48AP",  "iPad",                       "iphoneos", "armv7"),
+                          ADD_DEVICE("K93AP",  "iPad 2",                     "iphoneos", "armv7"),
+                          ADD_DEVICE("K94AP",  "iPad 2 (GSM)",               "iphoneos", "armv7"),
+                          ADD_DEVICE("K95AP",  "iPad 2 (CDMA)",              "iphoneos", "armv7"),
+                          ADD_DEVICE("K93AAP", "iPad 2 (Wi-Fi, revision A)", "iphoneos", "armv7"),
+                          ADD_DEVICE("J1AP",   "iPad 3",                     "iphoneos", "armv7"),
+                          ADD_DEVICE("J2AP",   "iPad 3 (GSM)",               "iphoneos", "armv7"),
+                          ADD_DEVICE("J2AAP",  "iPad 3 (CDMA)",              "iphoneos", "armv7"),
+                          ADD_DEVICE("P101AP", "iPad 4",                     "iphoneos", "armv7s"),
+                          ADD_DEVICE("P102AP", "iPad 4 (GSM)",               "iphoneos", "armv7s"),
+                          ADD_DEVICE("P103AP", "iPad 4 (CDMA)",              "iphoneos", "armv7s"),
+                          ADD_DEVICE("J71AP",  "iPad Air",                   "iphoneos", "arm64"),
+                          ADD_DEVICE("J72AP",  "iPad Air (GSM)",             "iphoneos", "arm64"),
+                          ADD_DEVICE("J73AP",  "iPad Air (CDMA)",            "iphoneos", "arm64"),
+                          ADD_DEVICE("J81AP",  "iPad Air 2",                 "iphoneos", "arm64"),
+                          ADD_DEVICE("J82AP",  "iPad Air 2 (GSM)",           "iphoneos", "arm64"),
+                          ADD_DEVICE("J83AP",  "iPad Air 2 (CDMA)",          "iphoneos", "arm64"),
+
+                          // iPad Pro
+
+                          ADD_DEVICE("J98aAP",  "iPad Pro (12.9\")",         "iphoneos", "arm64"),
+                          ADD_DEVICE("J99aAP",  "iPad Pro (12.9\")",         "iphoneos", "arm64"),
+                          ADD_DEVICE("J127AP",  "iPad Pro (9.7\")",          "iphoneos", "arm64"),
+                          ADD_DEVICE("J128AP",  "iPad Pro (9.7\")",          "iphoneos", "arm64"),
+
+                          // iPad Mini
+
+                          ADD_DEVICE("P105AP", "iPad mini",                  "iphoneos", "armv7"),
+                          ADD_DEVICE("P106AP", "iPad mini (GSM)",            "iphoneos", "armv7"),
+                          ADD_DEVICE("P107AP", "iPad mini (CDMA)",           "iphoneos", "armv7"),
+                          ADD_DEVICE("J85AP",  "iPad mini 2",                "iphoneos", "arm64"),
+                          ADD_DEVICE("J86AP",  "iPad mini 2 (GSM)",          "iphoneos", "arm64"),
+                          ADD_DEVICE("J87AP",  "iPad mini 2 (CDMA)",         "iphoneos", "arm64"),
+                          ADD_DEVICE("J85MAP", "iPad mini 3",                "iphoneos", "arm64"),
+                          ADD_DEVICE("J86MAP", "iPad mini 3 (GSM)",          "iphoneos", "arm64"),
+                          ADD_DEVICE("J87MAP", "iPad mini 3 (CDMA)",         "iphoneos", "arm64"),
+                          ADD_DEVICE("J96AP",  "iPad mini 4",                "iphoneos", "arm64"),
+                          ADD_DEVICE("J97AP",  "iPad mini 4 (GSM)",          "iphoneos", "arm64"),
+
+                          // iPhone
+
+                          ADD_DEVICE("M68AP",  "iPhone",                     "iphoneos", "armv7"),
+                          ADD_DEVICE("N82AP",  "iPhone 3G",                  "iphoneos", "armv7"),
+                          ADD_DEVICE("N88AP",  "iPhone 3GS",                 "iphoneos", "armv7"),
+                          ADD_DEVICE("N90AP",  "iPhone 4 (GSM)",             "iphoneos", "armv7"),
+                          ADD_DEVICE("N92AP",  "iPhone 4 (CDMA)",            "iphoneos", "armv7"),
+                          ADD_DEVICE("N90BAP", "iPhone 4 (GSM, revision A)", "iphoneos", "armv7"),
+                          ADD_DEVICE("N94AP",  "iPhone 4S",                  "iphoneos", "armv7"),
+                          ADD_DEVICE("N41AP",  "iPhone 5 (GSM)",             "iphoneos", "armv7s"),
+                          ADD_DEVICE("N42AP",  "iPhone 5 (Global/CDMA)",     "iphoneos", "armv7s"),
+                          ADD_DEVICE("N48AP",  "iPhone 5c (GSM)",            "iphoneos", "armv7s"),
+                          ADD_DEVICE("N49AP",  "iPhone 5c (Global/CDMA)",    "iphoneos", "armv7s"),
+                          ADD_DEVICE("N51AP",  "iPhone 5s (GSM)",            "iphoneos", "arm64"),
+                          ADD_DEVICE("N53AP",  "iPhone 5s (Global/CDMA)",    "iphoneos", "arm64"),
+                          ADD_DEVICE("N61AP",  "iPhone 6 (GSM)",             "iphoneos", "arm64"),
+                          ADD_DEVICE("N56AP",  "iPhone 6 Plus",              "iphoneos", "arm64"),
+                          ADD_DEVICE("N71mAP", "iPhone 6s",                  "iphoneos", "arm64"),
+                          ADD_DEVICE("N71AP",  "iPhone 6s",                  "iphoneos", "arm64"),
+                          ADD_DEVICE("N66AP",  "iPhone 6s Plus",             "iphoneos", "arm64"),
+                          ADD_DEVICE("N66mAP", "iPhone 6s Plus",             "iphoneos", "arm64"),
+                          ADD_DEVICE("N69AP",  "iPhone SE",                  "iphoneos", "arm64"),
+                          ADD_DEVICE("N69uAP", "iPhone SE",                  "iphoneos", "arm64"),
+                          ADD_DEVICE("D10AP",  "iPhone 7",                   "iphoneos", "arm64"),
+                          ADD_DEVICE("D101AP", "iPhone 7",                   "iphoneos", "arm64"),
+                          ADD_DEVICE("D11AP",  "iPhone 7 Plus",              "iphoneos", "arm64"),
+                          ADD_DEVICE("D111AP", "iPhone 7 Plus",              "iphoneos", "arm64"),
+
+                          // Apple TV
+
+                          ADD_DEVICE("K66AP",  "Apple TV 2G",                "appletvos", "armv7"),
+                          ADD_DEVICE("J33AP",  "Apple TV 3G",                "appletvos", "armv7"),
+                          ADD_DEVICE("J33IAP", "Apple TV 3.1G",              "appletvos", "armv7"),
+                          ADD_DEVICE("J42dAP", "Apple TV 4G",                "appletvos", "arm64"),
+                          };

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -293,7 +293,7 @@ device_desc get_device_desc(CFStringRef model) {
     if (model != NULL) {
         size_t sz = sizeof(device_db) / sizeof(device_desc);
         for (size_t i = 0; i < sz; i ++) {
-            if (CFStringCompare(model, device_db[i].model, kCFCompareNonliteral) == kCFCompareEqualTo) {
+            if (CFStringCompare(model, device_db[i].model, kCFCompareNonliteral | kCFCompareCaseInsensitive) == kCFCompareEqualTo) {
                 return device_db[i];
             }
         }
@@ -332,26 +332,27 @@ CFStringRef get_device_full_name(const AMDeviceRef device) {
 
     // Please ensure that device is connected or the name will be unknown
     CFStringRef model = AMDeviceCopyValue(device, 0, CFSTR("HardwareModel"));
-    if (model == NULL) {
-        model_name = device_db[UNKNOWN_DEVICE_IDX].name;
-        sdk_name = device_db[UNKNOWN_DEVICE_IDX].sdk;
-        arch_name = device_db[UNKNOWN_DEVICE_IDX].arch;
+    device_desc dev;
+    if (model != NULL) {
+        dev = get_device_desc(model);
     } else {
-        device_desc dev = get_device_desc(model);
-        model_name = dev.name;
-        sdk_name = dev.sdk;
-        arch_name = dev.arch;
+        dev= device_db[UNKNOWN_DEVICE_IDX];
+        model = dev.model;
     }
+    model_name = dev.name;
+    sdk_name = dev.sdk;
+    arch_name = dev.arch;
 
+    NSLogVerbose(@"Hardware Model: %@", model);
     NSLogVerbose(@"Device Name: %@", device_name);
     NSLogVerbose(@"Model Name: %@", model_name);
     NSLogVerbose(@"SDK Name: %@", sdk_name);
     NSLogVerbose(@"Architecture Name: %@", arch_name);
 
-    if (device_name != NULL && model_name != NULL) {
-        full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ a.k.a. '%@' (%@, %@, %@)"), device_udid, device_name, model_name, sdk_name, arch_name);
+    if (device_name != NULL) {
+        full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (%@, %@, %@, %@) a.k.a. '%@'"), device_udid, model, model_name, sdk_name, arch_name, device_name);
     } else {
-        full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ss"), device_udid);
+        full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ (%@, %@, %@, %@)"), device_udid, model, model_name, sdk_name, arch_name);
     }
 
     AMDeviceDisconnect(device);

--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -16,7 +16,8 @@
 #include <netinet/tcp.h>
 
 #include "MobileDevice.h"
-#include "errors.h"
+#import "errors.h"
+#import "device_db.h"
 
 #define PREP_CMDS_PATH @"/tmp/%@/fruitstrap-lldb-prep-cmds-"
 #define LLDB_SHELL @"lldb -s %@"
@@ -288,91 +289,16 @@ CFStringRef copy_xcode_path_for(CFStringRef subPath, CFStringRef search) {
     }
 }
 
-#define GET_FRIENDLY_MODEL_NAME(VALUE, INTERNAL_NAME, FRIENDLY_NAME)  if (kCFCompareEqualTo  == CFStringCompare(VALUE, CFSTR(INTERNAL_NAME), kCFCompareNonliteral)) { return CFSTR( FRIENDLY_NAME); };
-
-
-// Please ensure that device is connected or the name will be unknown
-const CFStringRef get_device_hardware_name(const AMDeviceRef device) {
-    CFStringRef model = AMDeviceCopyValue(device, 0, CFSTR("HardwareModel"));
-
-    if (model == NULL) {
-        return CFSTR("Unknown Device");
+device_desc get_device_desc(CFStringRef model) {
+    if (model != NULL) {
+        size_t sz = sizeof(device_db) / sizeof(device_desc);
+        for (size_t i = 0; i < sz; i ++) {
+            if (CFStringCompare(model, device_db[i].model, kCFCompareNonliteral) == kCFCompareEqualTo) {
+                return device_db[i];
+            }
+        }
     }
-
-    // iPod Touch
-
-    GET_FRIENDLY_MODEL_NAME(model, "N45AP",  "iPod Touch")
-    GET_FRIENDLY_MODEL_NAME(model, "N72AP",  "iPod Touch 2G")
-    GET_FRIENDLY_MODEL_NAME(model, "N18AP",  "iPod Touch 3G")
-    GET_FRIENDLY_MODEL_NAME(model, "N81AP",  "iPod Touch 4G")
-    GET_FRIENDLY_MODEL_NAME(model, "N78AP",  "iPod Touch 5G")
-    GET_FRIENDLY_MODEL_NAME(model, "N78AAP", "iPod Touch 5G")
-
-    // iPad
-
-    GET_FRIENDLY_MODEL_NAME(model, "K48AP",  "iPad")
-    GET_FRIENDLY_MODEL_NAME(model, "K93AP",  "iPad 2")
-    GET_FRIENDLY_MODEL_NAME(model, "K94AP",  "iPad 2 (GSM)")
-    GET_FRIENDLY_MODEL_NAME(model, "K95AP",  "iPad 2 (CDMA)")
-    GET_FRIENDLY_MODEL_NAME(model, "K93AAP", "iPad 2 (Wi-Fi, revision A)")
-    GET_FRIENDLY_MODEL_NAME(model, "J1AP",   "iPad 3")
-    GET_FRIENDLY_MODEL_NAME(model, "J2AP",   "iPad 3 (GSM)")
-    GET_FRIENDLY_MODEL_NAME(model, "J2AAP",  "iPad 3 (CDMA)")
-    GET_FRIENDLY_MODEL_NAME(model, "P101AP", "iPad 4")
-    GET_FRIENDLY_MODEL_NAME(model, "P102AP", "iPad 4 (GSM)")
-    GET_FRIENDLY_MODEL_NAME(model, "P103AP", "iPad 4 (CDMA)")
-
-    // iPad Pro
-
-    GET_FRIENDLY_MODEL_NAME(model, "J98aAP",  "iPad Pro (12.9\")")
-    GET_FRIENDLY_MODEL_NAME(model, "J98aAP",  "iPad Pro (12.9\")")
-    GET_FRIENDLY_MODEL_NAME(model, "J127AP",  "iPad Pro (9.7\")")
-    GET_FRIENDLY_MODEL_NAME(model, "J128AP",  "iPad Pro (9.7\")")
-
-    // iPad Mini
-
-    GET_FRIENDLY_MODEL_NAME(model, "P105AP", "iPad mini")
-    GET_FRIENDLY_MODEL_NAME(model, "P106AP", "iPad mini (GSM)")
-    GET_FRIENDLY_MODEL_NAME(model, "P107AP", "iPad mini (CDMA)")
-
-    // Apple TV
-
-    GET_FRIENDLY_MODEL_NAME(model, "K66AP",  "Apple TV 2G")
-    GET_FRIENDLY_MODEL_NAME(model, "J33AP",  "Apple TV 3G")
-    GET_FRIENDLY_MODEL_NAME(model, "J33IAP", "Apple TV 3.1G")
-    GET_FRIENDLY_MODEL_NAME(model, "J42dAP", "Apple TV 4G")
-
-    // iPhone
-
-    GET_FRIENDLY_MODEL_NAME(model, "M68AP", "iPhone")
-    GET_FRIENDLY_MODEL_NAME(model, "N82AP", "iPhone 3G")
-    GET_FRIENDLY_MODEL_NAME(model, "N88AP", "iPhone 3GS")
-    GET_FRIENDLY_MODEL_NAME(model, "N90AP", "iPhone 4 (GSM)")
-    GET_FRIENDLY_MODEL_NAME(model, "N92AP", "iPhone 4 (CDMA)")
-    GET_FRIENDLY_MODEL_NAME(model, "N90BAP", "iPhone 4 (GSM, revision A)")
-    GET_FRIENDLY_MODEL_NAME(model, "N94AP", "iPhone 4S")
-    GET_FRIENDLY_MODEL_NAME(model, "N41AP", "iPhone 5 (GSM)")
-    GET_FRIENDLY_MODEL_NAME(model, "N42AP", "iPhone 5 (Global/CDMA)")
-    GET_FRIENDLY_MODEL_NAME(model, "N48AP", "iPhone 5c (GSM)")
-    GET_FRIENDLY_MODEL_NAME(model, "N49AP", "iPhone 5c (Global/CDMA)")
-    GET_FRIENDLY_MODEL_NAME(model, "N51AP", "iPhone 5s (GSM)")
-    GET_FRIENDLY_MODEL_NAME(model, "N53AP", "iPhone 5s (Global/CDMA)")
-    GET_FRIENDLY_MODEL_NAME(model, "N61AP", "iPhone 6 (GSM)")
-    GET_FRIENDLY_MODEL_NAME(model, "N56AP", "iPhone 6 Plus")
-    GET_FRIENDLY_MODEL_NAME(model, "N71mAP", "iPhone 6s")
-    GET_FRIENDLY_MODEL_NAME(model, "N71AP", "iPhone 6s")
-    GET_FRIENDLY_MODEL_NAME(model, "N66AP", "iPhone 6s Plus")
-    GET_FRIENDLY_MODEL_NAME(model, "N66mAP", "iPhone 6s Plus")
-    GET_FRIENDLY_MODEL_NAME(model, "N69AP", "iPhone SE")
-    GET_FRIENDLY_MODEL_NAME(model, "N69uAP", "iPhone SE")
-
-    GET_FRIENDLY_MODEL_NAME(model, "D10AP", "iPhone 7")
-    GET_FRIENDLY_MODEL_NAME(model, "D101AP", "iPhone 7")
-    GET_FRIENDLY_MODEL_NAME(model, "D11AP", "iPhone 7 Plus")
-    GET_FRIENDLY_MODEL_NAME(model, "D111AP", "iPhone 7 Plus")
-    
-
-    return model;
+    return device_db[UNKNOWN_DEVICE_IDX];
 }
 
 char * MYCFStringCopyUTF8String(CFStringRef aString) {
@@ -396,23 +322,36 @@ CFStringRef get_device_full_name(const AMDeviceRef device) {
     CFStringRef full_name = NULL,
                 device_udid = AMDeviceCopyDeviceIdentifier(device),
                 device_name = NULL,
-                model_name = NULL;
+                model_name = NULL,
+                sdk_name = NULL,
+                arch_name = NULL;
 
     AMDeviceConnect(device);
 
-    device_name = AMDeviceCopyValue(device, 0, CFSTR("DeviceName")),
-    model_name = get_device_hardware_name(device);
+    device_name = AMDeviceCopyValue(device, 0, CFSTR("DeviceName"));
+
+    // Please ensure that device is connected or the name will be unknown
+    CFStringRef model = AMDeviceCopyValue(device, 0, CFSTR("HardwareModel"));
+    if (model == NULL) {
+        model_name = device_db[UNKNOWN_DEVICE_IDX].name;
+        sdk_name = device_db[UNKNOWN_DEVICE_IDX].sdk;
+        arch_name = device_db[UNKNOWN_DEVICE_IDX].arch;
+    } else {
+        device_desc dev = get_device_desc(model);
+        model_name = dev.name;
+        sdk_name = dev.sdk;
+        arch_name = dev.arch;
+    }
 
     NSLogVerbose(@"Device Name: %@", device_name);
     NSLogVerbose(@"Model Name: %@", model_name);
+    NSLogVerbose(@"SDK Name: %@", sdk_name);
+    NSLogVerbose(@"Architecture Name: %@", arch_name);
 
-    if(device_name != NULL && model_name != NULL)
-    {
-        full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ '%@' (%@)"), model_name, device_name, device_udid);
-    }
-    else
-    {
-        full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("(%@ss)"), device_udid);
+    if (device_name != NULL && model_name != NULL) {
+        full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ a.k.a. '%@' (%@, %@, %@)"), device_udid, device_name, model_name, sdk_name, arch_name);
+    } else {
+        full_name = CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ss"), device_udid);
     }
 
     AMDeviceDisconnect(device);
@@ -973,7 +912,7 @@ void setup_dummy_pipe_on_stdin(int pfd[2]) {
 
 void setup_lldb(AMDeviceRef device, CFURLRef url) {
     CFStringRef device_full_name = get_device_full_name(device),
-    device_interface_name = get_device_interface_name(device);
+                device_interface_name = get_device_interface_name(device);
 
     AMDeviceConnect(device);
     assert(AMDeviceIsPaired(device));


### PR DESCRIPTION
Added additional sdk and arch info to each device entry.
Updated some missing or wrong definitions.
Changed the full name output string format to ~~"device_id a.k.a. 'device_name' (model, sdk, arch)"~~ "device_id (hwmodel, model, sdk, arch) a.k.a. 'device_name'".

It was done to ease some automated testing when working with multiple devices connected to the same Mac (the Apple TV and iOS devices use different SDKs for example). Just thought it might be helpful for others too.
