### PR TITLE
Look for the developer disk image using more patterns as well

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -430,6 +430,10 @@ CFStringRef copy_device_support_path(AMDeviceRef device, CFStringRef suffix) {
             if (path == NULL) {
                 path = copy_xcode_path_for(deviceClassPath[i], CFStringCreateWithFormat(NULL, NULL, CFSTR("%@/%@"), version, suffix));
             }
+
+            if (path == NULL) {
+                path = copy_xcode_path_for(deviceClassPath[i], CFStringCreateWithFormat(NULL, NULL, CFSTR("%@.*/%@"), version, suffix));
+            }
         }
         
         CFRelease(version);


### PR DESCRIPTION
Xcode 8.3.3 contains the following directories in
Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport:
10.0			8.1			9.1
10.1			8.2			9.2
10.2			8.3			9.3
10.3.1 (14E8301)	8.4
8.0			9.0

Despite this, this version of Xcode can run code on iOS devices
running iOS 10.3.2 as well.

Therefore try with a pattern of "<version>.*", which for 10.3.2
matches when the last version component has been stripped, into 10.3.

This fixes the latest occurrances of github issue #171.