### PR TITLE
Added an option `--detect_deadlocks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ If you are *not* using a node version manager like [nvm](https://github.com/crea
         -e, --exists                 check if the app with given bundle_id is installed or not 
         -B, --list_bundle_id         list bundle_id 
         -W, --no-wifi                ignore wifi devices
+        --detect_deadlocks <sec>     start printing backtraces for all threads periodically after specific amount of seconds
 
 ## Examples
 
@@ -142,3 +143,6 @@ The included demo.app represents the minimum required to get code running on iOS
 
 * `make demo.app` will generate the demo.app executable. If it doesn't compile, modify `IOS_SDK_VERSION` in the Makefile.
 * `make debug` will install demo.app and launch a LLDB session.
+
+## Notes
+* `--detect_deadlocks` can help to identify an exact state of application's threads in case of a deadlock. It works like this: The user specifies the amount of time ios-deploy runs the app as usual. When the timeout is elapsed ios-deploy starts to print call-stacks of all threads every 5 seconds and the app keeps running. Comparing threads' call-stacks between each other helps to identify the threads which were stuck.

--- a/src/scripts/lldb.py
+++ b/src/scripts/lldb.py
@@ -1,7 +1,8 @@
-import lldb
+import time
 import os
 import sys
 import shlex
+import lldb
 
 listener = None
 
@@ -73,6 +74,9 @@ def safequit_command(debugger, command, result, internal_dict):
 def autoexit_command(debugger, command, result, internal_dict):
     global listener
     process = lldb.target.process
+
+    detectDeadlockTimeout = {detect_deadlock_timeout}
+    printBacktraceTime = time.time() + detectDeadlockTimeout if detectDeadlockTimeout > 0 else None
     
     # This line prevents internal lldb listener from processing STDOUT/STDERR messages. Without it, an order of log writes is incorrect sometimes
     debugger.GetListener().StopListeningForEvents(process.GetBroadcaster(), lldb.SBProcess.eBroadcastBitSTDOUT | lldb.SBProcess.eBroadcastBitSTDERR )
@@ -113,7 +117,7 @@ def autoexit_command(debugger, command, result, internal_dict):
         if state == lldb.eStateExited:
             sys.stdout.write( '\\nPROCESS_EXITED\\n' )
             os._exit(process.GetExitStatus())
-        elif state == lldb.eStateStopped:
+        elif printBacktraceTime is None and state == lldb.eStateStopped:
             sys.stdout.write( '\\nPROCESS_STOPPED\\n' )
             debugger.HandleCommand('bt')
             os._exit({exitcode_app_crash})
@@ -124,4 +128,10 @@ def autoexit_command(debugger, command, result, internal_dict):
         elif state == lldb.eStateDetached:
             sys.stdout.write( '\\nPROCESS_DETACHED\\n' )
             os._exit({exitcode_app_crash})
-
+        elif printBacktraceTime is not None and time.time() >= printBacktraceTime:
+            printBacktraceTime = None
+            sys.stdout.write( '\\nPRINT_BACKTRACE_TIMEOUT\\n' )
+            debugger.HandleCommand('process interrupt')
+            debugger.HandleCommand('bt all')
+            debugger.HandleCommand('continue')
+            printBacktraceTime = time.time() + 5


### PR DESCRIPTION
Added an option `--detect_deadlocks` which can help to identify an exact state of application's threads in case of a deadlock. It works like this: The user specifies the amount of time ios-deploy runs the app as usual. When the timeout is elapsed ios-deploy starts to print call-stacks of all threads every 5 seconds and the app keeps running. Comparing threads' call-stacks between each other helps to identify the threads which were stuck.