### PR TITLE
Fixed: `--detect` didn't return any info for devices missed in the DB

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -303,7 +303,13 @@ device_desc get_device_desc(CFStringRef model) {
             }
         }
     }
-    return device_db[UNKNOWN_DEVICE_IDX];
+    
+    device_desc res = device_db[UNKNOWN_DEVICE_IDX];
+    
+    res.model = model;
+    res.name = model;
+    
+    return res;
 }
 
 char * MYCFStringCopyUTF8String(CFStringRef aString) {


### PR DESCRIPTION
It returns at least internal HardwareModel now.