### PR TITLE
Don't exit program in the justlaunch mode when timeout

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1662,6 +1662,10 @@ void device_callback(struct am_device_notification_callback_info *info, void *ar
 
 void timeout_callback(CFRunLoopTimerRef timer, void *info) {
     if (found_device && (!detect_only)) {
+        // Don't need to exit in the justlaunch mode
+        if (justlaunch)
+            return;
+
         // App running for too long
         NSLog(@"[ !! ] App is running for too long");
         exit(exitcode_timeout);


### PR DESCRIPTION
I think we don't need to exit the program in 'justlaunch' mode when timeout, because it will kill lldb in case of timeout is small.

Ex: The below code cannot launch the app because it will break after 1s.
```
ios-deploy -t 1 --justlaunch --bundle ./test.app
```