### PR TITLE
Fix Anchor for 10.11 or Greater Message

### DIFF
--- a/src/scripts/check_reqs.js
+++ b/src/scripts/check_reqs.js
@@ -43,7 +43,7 @@ xcode_version.on('close', function (code) {
 			console.log('!!!! WARNING:   `--unsafe-perm=true` flag when running `npm install`');
 			console.log('!!!! WARNING:   or else it will fail.');
 			console.log('!!!! WARNING: link:');
-			console.log('!!!! WARNING:   https://github.com/phonegap/ios-deploy#os-x-1011-el-capitan');
+			console.log('!!!! WARNING:   https://github.com/phonegap/ios-deploy#os-x-1011-el-capitan-or-greater');
 			console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
 		}
 		


### PR DESCRIPTION
The anchor in the code is not correct or is not longer correct. This anchor correctly drops the user at the right place on the rendered README.