### PR TITLE
A proposed external LLDB command file and Python script support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _Frameworks/*
 *~
 src/scripts/lldb.pyc
 src/ios-deploy/lldb.py.h
+src/ios-deploy/lldb_cmds.h

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ If you are *not* using a node version manager like [nvm](https://github.com/crea
         -B, --list_bundle_id         list bundle_id 
         -W, --no-wifi                ignore wifi devices
         --detect_deadlocks <sec>     start printing backtraces for all threads periodically after specific amount of seconds
+        --custom_prep_cmds <file>    use custom LLDB commands file for communication with the device
+        --custom_lldb_script <file>  use custom LLDB python script file for managing the process lifecycle
 
 ## Examples
 
@@ -136,6 +138,9 @@ The commands below assume that you have an app called `my.app` with bundle id `b
     
     // list all bundle ids of all apps on your device
     ios-deploy --list_bundle_id
+    
+    // deploy and launch your app to a connected device with a custom LLDB command file and python script
+    ios-deploy --noninteractive --bundle my.app --custom_prep_cmds lldb_cmds --custom_lldb_scrupt lldb.py
 
 ## Demo
 

--- a/ios-deploy.xcodeproj/project.pbxproj
+++ b/ios-deploy.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 
 /* Begin PBXFileReference section */
 		7B28C98C1DC10655009569B6 /* device_db.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = device_db.h; sourceTree = "<group>"; };
+		7B757511209A0CE100B885EB /* lldb_cmds */ = {isa = PBXFileReference; lastKnownFileType = text; path = lldb_cmds; sourceTree = "<group>"; };
+		7BFA2AB8209B0CDD00A7DA2F /* lldb_cmds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lldb_cmds.h; sourceTree = "<group>"; };
 		7E1C00CC1C3C93AF00D686B5 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
 		7E1C00CF1C3C9ABB00D686B5 /* lldb.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; name = lldb.py; path = src/scripts/lldb.py; sourceTree = SOURCE_ROOT; };
 		7E1C00D11C3C9CB000D686B5 /* lldb.py.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lldb.py.h; sourceTree = "<group>"; };
@@ -88,6 +90,7 @@
 			children = (
 				7EDCC3CE1C45DFF0002F9851 /* check_reqs.js */,
 				7E1C00CF1C3C9ABB00D686B5 /* lldb.py */,
+				7B757511209A0CE100B885EB /* lldb_cmds */,
 			);
 			name = scripts;
 			path = src/scripts;
@@ -119,6 +122,7 @@
 			isa = PBXGroup;
 			children = (
 				7E1C00D11C3C9CB000D686B5 /* lldb.py.h */,
+				7BFA2AB8209B0CDD00A7DA2F /* lldb_cmds.h */,
 				7E1C00CC1C3C93AF00D686B5 /* version.h */,
 				7E7089991B587DE4004D23AA /* ios-deploy.m */,
 				7E70899A1B587DE4004D23AA /* errors.h */,
@@ -177,6 +181,7 @@
 			buildConfigurationList = 7E7089951B587BF3004D23AA /* Build configuration list for PBXNativeTarget "ios-deploy" */;
 			buildPhases = (
 				7EDCC3CF1C45E03B002F9851 /* ShellScript */,
+				7B757512209A0D1E00B885EB /* ShellScript */,
 				C0CD3D981F59D20100F954DB /* ShellScript */,
 				7E70898B1B587BF3004D23AA /* Frameworks */,
 				7EDCC3CC1C45DC89002F9851 /* Sources */,
@@ -305,6 +310,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "rm -rf \"${PROJECT_DIR}/_Frameworks\"";
+		};
+		7B757512209A0D1E00B885EB /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"\\\"# AUTO-GENERATED - DO NOT MODIFY\\n\\\"\" > src/ios-deploy/lldb_cmds.h\nawk '{ print \"\\\"\"$0\"\\\\n\\\"\"}' src/scripts/lldb_cmds >> src/ios-deploy/lldb_cmds.h";
 		};
 		7EDCC3CF1C45E03B002F9851 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/src/scripts/lldb_cmds
+++ b/src/scripts/lldb_cmds
@@ -1,0 +1,12 @@
+platform select remote-ios --sysroot '{symbols_path}'
+target create '{disk_app}'
+script fruitstrap_device_app='{device_app}'
+script fruitstrap_connect_url='connect://127.0.0.1:{device_port}'
+target modules search-paths add {modules_search_paths_pairs}
+command script import '{python_file_path}'
+command script add -f {python_command}.connect_command connect
+command script add -s asynchronous -f {python_command}.run_command run
+command script add -s asynchronous -f {python_command}.autoexit_command autoexit
+command script add -s asynchronous -f {python_command}.safequit_command safequit
+connect
+{run_commands}


### PR DESCRIPTION
I wrote a proposal in https://github.com/shazron/phonegap-questions/issues/57

Here is the implementation of the first solution - two arguments that would add ability to pass custom LLDB commands and a custom Python script to handle communication with the process. This will require for the user to implement the whole "fruitstrap" logic on their own side, but it also gives way for custom communication with LLDB Python APIs which wasn't possible before.