### PR TITLE
Fix #578: Pass in CFNumberRef correctly instead of passing 0 as int

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -1512,7 +1512,10 @@ void setup_lldb(AMDeviceRef device, CFURLRef url) {
         NSLogOut(@"[100%%] Listening for lldb connections");
     }
     else {
-        create_remote_debug_server_socket(0, device);   // start debugserver
+        int connection_id = 0;
+        CFNumberRef cf_connection_id = CFAutorelease(CFNumberCreate(NULL, kCFNumberIntType, &connection_id));
+
+        create_remote_debug_server_socket(cf_connection_id, device);   // start debugserver
         write_lldb_prep_cmds(device, url);   // dump the necessary lldb commands into a file
         NSLogOut(@"[100%%] Connecting to remote debug server");
     }


### PR DESCRIPTION
Fix #578. It was crashing due to one incorrect handling of CFNumberRef in #527.

We were passing 0 as int when the method `create_remote_debug_server_socket` was expecting a CFNumberRef and the 0 was treated as nil, causing the crash.