### PR TITLE
Update ios-deploy.m

### DIFF
--- a/src/ios-deploy/ios-deploy.m
+++ b/src/ios-deploy/ios-deploy.m
@@ -36,6 +36,7 @@
     command script import \"{python_file_path}\"\n\
     command script add -f {python_command}.connect_command connect\n\
     command script add -s asynchronous -f {python_command}.run_command run\n\
+    command alias r run\n\
     command script add -s asynchronous -f {python_command}.autoexit_command autoexit\n\
     command script add -s asynchronous -f {python_command}.safequit_command safequit\n\
     connect\n\


### PR DESCRIPTION
Extend the LLDB_PREP_CMDS macro so that the alias "r", which is commonly used in LLDB, can be used for the newly defined "run". 

This is a common annoyance I have found with using ios-deploy, as running what is bound to the alias "r" makes lldb fail to launch. Now "run" does not work, as the platform is not connected anymore. In order to make it work again, you have to restart and correctly type "run".